### PR TITLE
Feature: add laser filters

### DIFF
--- a/turtlebot2_bringup/config/turtlebot2_laser_scan_filter.yaml
+++ b/turtlebot2_bringup/config/turtlebot2_laser_scan_filter.yaml
@@ -1,0 +1,14 @@
+scan_to_scan_filter_chain:
+  ros__parameters:
+    filter1:
+      name: pole_right
+      type: laser_filters/LaserScanAngularBoundsFilterInPlace
+      params:
+        lower_angle: -1.78
+        upper_angle: -1.63
+    filter2:
+      name: pole_left
+      type: laser_filters/LaserScanAngularBoundsFilterInPlace
+      params:
+        lower_angle: 1.65
+        upper_angle: 1.80

--- a/turtlebot2_bringup/launch/turtlebot2_bringup.launch.py
+++ b/turtlebot2_bringup/launch/turtlebot2_bringup.launch.py
@@ -97,7 +97,6 @@ def generate_launch_description():
         ])
     )
 
-
     laser_filter = LaunchDescription()
     laser_filter_node = launch_ros.actions.Node(
         package='laser_filters',

--- a/turtlebot2_bringup/launch/turtlebot2_bringup.launch.py
+++ b/turtlebot2_bringup/launch/turtlebot2_bringup.launch.py
@@ -71,14 +71,20 @@ def generate_launch_description():
         ])
     )
 
-    slam_node = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([
-            PathJoinSubstitution([
-                FindPackageShare('slam_toolbox'),
-                'launch',
-                'online_async_launch.py'
-            ])
-        ])
+    slam_node = GroupAction(
+        actions=[
+            launch_ros.actions.SetRemap( src='/scan', dst='/scan_filtered'),
+
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource([
+                    PathJoinSubstitution([
+                        FindPackageShare('slam_toolbox'),
+                        'launch',
+                        'online_async_launch.py'
+                    ])
+                ])
+            )
+        ]
     )
 
     nav_node = IncludeLaunchDescription(
@@ -90,10 +96,25 @@ def generate_launch_description():
             ])
         ])
     )
+
+
+    laser_filter = LaunchDescription()
+    laser_filter_node = launch_ros.actions.Node(
+        package='laser_filters',
+        executable='scan_to_scan_filter_chain',
+        parameters=[
+            PathJoinSubstitution([
+                FindPackageShare('turtlebot2_bringup'),
+                'config',
+                'turtlebot2_laser_scan_filter.yaml'
+            ])],
+        )
+    laser_filter.add_action( laser_filter_node )
     
     return LaunchDescription([
         robot_model,
         laser_node,
+        laser_filter,
         kobuki_node,
         #robot_localization_node
         slam_node,

--- a/turtlebot2_bringup/package.xml
+++ b/turtlebot2_bringup/package.xml
@@ -12,7 +12,7 @@
   <exec_depend>xacro</exec_depend>
   <exec_depend>turtlebot2_description</exec_depend>
   <exec_depend>robot_localization</exec_depend>
-
+  <exec_depend>laser_filters</exec_depend>
   
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/turtlebot2_bringup/package.xml
+++ b/turtlebot2_bringup/package.xml
@@ -11,8 +11,12 @@
 
   <exec_depend>xacro</exec_depend>
   <exec_depend>turtlebot2_description</exec_depend>
-  <exec_depend>robot_localization</exec_depend>
+  <exec_depend>urg_node</exec_depend>
+  <!--<exec_depend>kobuki_node</exec_depend>-->
   <exec_depend>laser_filters</exec_depend>
+  <exec_depend>robot_localization</exec_depend>
+  <exec_depend>slam_toolbox</exec_depend>
+  <exec_depend>navigation2</exec_depend>
   
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/turtlebot2_description/package.xml
+++ b/turtlebot2_description/package.xml
@@ -7,12 +7,14 @@
   <maintainer email="proan@ingotrobotics.com">Phil Roan</maintainer>
   <license>Apache 2.0</license>
 
+  <!--<depend>kobuki_description</depend>-->
+  
   <buildtool_depend>ament_cmake</buildtool_depend>
-
+  
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>xacro</exec_depend>
-
+  
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/turtlebot2_ros2.dockerfile
+++ b/turtlebot2_ros2.dockerfile
@@ -4,7 +4,7 @@ ARG from_image=ros:iron
 ARG robot_workspace="/root/robot"
 
 #FROM osrf/ros:iron-desktop
-FROM $from_image AS builder
+FROM $from_image AS kobuki_builder
 MAINTAINER proan@ingotrobotics.com
 
 RUN apt-get update && apt-get upgrade -y && apt-get install wget -y
@@ -58,9 +58,9 @@ ENV ROBOT_WORKSPACE=$robot_workspace
 
 WORKDIR $ROBOT_WORKSPACE
 RUN mkdir -p $ROBOT_WORKSPACE/install
-COPY --from=builder $ROBOT_WORKSPACE/install/ install
+COPY --from=kobuki_builder $ROBOT_WORKSPACE/install/ install
 
-# Install dependencies with rosdep
+# Install Kobuki dependencies with rosdep
 WORKDIR $ROBOT_WORKSPACE
 RUN apt-get update && apt-get upgrade -y && rosdep install --from-paths ./install/*/ -y --ignore-src
 
@@ -73,27 +73,14 @@ RUN sed -i "s/node_executable='urg_node'/executable='urg_node_driver'/g" /opt/ro
 # Patch urg_node_serial.yaml (temporary fix, really should be changing the launch file)
 RUN sed -i 's/laser_frame_id: "laser"/laser_frame_id: "nav_laser"/g' /opt/ros/$ROS_DISTRO/share/urg_node/launch/urg_node_serial.yaml
 
-# Install RealSense (for D435)
-RUN apt-get update && apt-get install ros-$ROS_DISTRO-realsense2-* -y
-
-# Setup Turtlebot2 URDF
-#COPY turtlebot2_description/ $ROBOT_WORKSPACE/src/turtlebot2_description
-#COPY turtlebot2_bringup/ $ROBOT_WORKSPACE/src/turtlebot2_bringup
-#RUN --mount=type=bind,source=.,target=$ROBOT_WORKSPACE/src,readonly \
-#    mkdir -p $ROBOT_WORKSPACE/src
-# Pre-copied URDF and xacro files from https://github.com/turtlebot/turtlebot.git into our turtlebot2_description folder
-
-
-# Install Nav2 bringup package
-#RUN apt-get update && apt-get install -y \
-#    ros-$ROS_DISTRO-nav2-bringup \
-
-# Install dependencies
+# Install Turtlebot dependencies with rosdep
 WORKDIR $ROBOT_WORKSPACE
 RUN --mount=type=bind,source=.,target=$ROBOT_WORKSPACE/src,readonly \
     apt-get update && rosdep install --from-paths ./src -y --ignore-src
 
 # Build turtlebot2_description and turtlebot2_bringup
+# The URDF and xacro files come from https://github.com/turtlebot/turtlebot.git
+# and have been copied into the turtlebot2_description folder
 SHELL ["/bin/bash", "-c"]
 ARG parallel_jobs=8
 RUN --mount=type=bind,source=.,target=$ROBOT_WORKSPACE/src,readonly \
@@ -101,6 +88,9 @@ RUN --mount=type=bind,source=.,target=$ROBOT_WORKSPACE/src,readonly \
     cd $ROBOT_WORKSPACE && \
     colcon build --packages-select turtlebot2_description turtlebot2_bringup --parallel-workers $parallel_jobs --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
+# Install Nav2 bringup package
+RUN apt-get update && apt-get install -y \
+    ros-$ROS_DISTRO-nav2-bringup
 
 # Kobuki udev rules for host machine
 # `wget https://raw.githubusercontent.com/kobuki-base/kobuki_ftdi/devel/60-kobuki.rules`

--- a/turtlebot2_ros2.dockerfile
+++ b/turtlebot2_ros2.dockerfile
@@ -73,6 +73,8 @@ RUN sed -i "s/node_executable='urg_node'/executable='urg_node_driver'/g" /opt/ro
 # Patch urg_node_serial.yaml (temporary fix, really should be changing the launch file)
 RUN sed -i 's/laser_frame_id: "laser"/laser_frame_id: "nav_laser"/g' /opt/ros/$ROS_DISTRO/share/urg_node/launch/urg_node_serial.yaml
 
+# Install RealSense (for D435)
+RUN apt-get update && apt-get install ros-$ROS_DISTRO-realsense2-* -y
 
 # Setup Turtlebot2 URDF
 #COPY turtlebot2_description/ $ROBOT_WORKSPACE/src/turtlebot2_description
@@ -81,17 +83,15 @@ RUN sed -i 's/laser_frame_id: "laser"/laser_frame_id: "nav_laser"/g' /opt/ros/$R
 #    mkdir -p $ROBOT_WORKSPACE/src
 # Pre-copied URDF and xacro files from https://github.com/turtlebot/turtlebot.git into our turtlebot2_description folder
 
+
+# Install Nav2 bringup package
+#RUN apt-get update && apt-get install -y \
+#    ros-$ROS_DISTRO-nav2-bringup \
+
 # Install dependencies
 WORKDIR $ROBOT_WORKSPACE
 RUN --mount=type=bind,source=.,target=$ROBOT_WORKSPACE/src,readonly \
     apt-get update && rosdep install --from-paths ./src -y --ignore-src
-
-# Install Nav2 packages
-RUN apt-get update && apt-get install -y \
-    ros-$ROS_DISTRO-navigation2 \
-    ros-$ROS_DISTRO-nav2-bringup \
-    ros-$ROS_DISTRO-robot-localization \
-    ros-$ROS_DISTRO-slam-toolbox
 
 # Build turtlebot2_description and turtlebot2_bringup
 SHELL ["/bin/bash", "-c"]
@@ -118,9 +118,3 @@ RUN --mount=type=bind,source=.,target=$ROBOT_WORKSPACE/src,readonly \
 # `ros2 run kobuki_keyop kobuki_keyop_node`
 # or
 # `ros2 run teleop_twist_keyboard teleop_twist_keyboard`
-
-
-# Install laser filers
-RUN apt-get update && apt-get install ros-$ROS_DISTRO-laser-filters -y
-
-


### PR DESCRIPTION
Add laser filter to remove pole reflections. Reflections from the poles holding the top plate to the Turtlebot2 cause obstacles to be placed inside the robot footprint, which in turn, prevents the navigation stack from moving the robot.