### PR TITLE
Update dockerfile based on lint results

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
                 }
             }
             steps {
-                sh 'hadolint turtlebot2_ros2.dockerfile | tee -a hadolint_lint.txt'
+                sh 'hadolint --ignore DL3006 --ignore DL3008 turtlebot2_ros2.dockerfile | tee -a hadolint_lint.txt'
             }
             post {
                 always {


### PR DESCRIPTION
Closes #5 

Linter returns 1 comment about multiple RUN commands. Right now those are separated to make it easy to see what is going on and to add packages for sensors.