### PR TITLE
Feature: build on ROS 2 Jazzy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 // Jenkinsfile to lint, build, and test turtlebot2_ros2 repo
 
 // Supported ROS 2 versions are given in the `rosVersions` list
-def rosVersions = ['iron', 'humble'] //'jazzy'
+def rosVersions = ['jazzy', 'iron', 'humble']
 
 // For each ROS 2 version, build from the official docker image and the OSRF
 // desktop image

--- a/kobuki_standalone.repos
+++ b/kobuki_standalone.repos
@@ -1,0 +1,14 @@
+#
+# Description       : Repos needed for a standalone build of kobuki
+# Versions          : ROS 2 Jazzy, Iron, and Humble
+# Build Dependencies: colcon-core, colcon-common-extensions
+#
+repositories:
+  # Kobuki dependencies
+  ecl_lite         : { type: 'git', url: 'https://github.com/ingotrobotics/ecl_lite.git',   version: 'bugfix/jazzy_error_overloaded-virtual' }
+  ecl_core         : { type: 'git', url: 'https://github.com/stonier/ecl_core.git',         version: 'devel' }
+
+  # Kobuki
+  kobuki_core      : { type: 'git', url: 'https://github.com/kobuki-base/kobuki_core.git',  version: 'devel' }
+  kobuki_ros       : { type: 'git', url: 'https://github.com/ingotrobotics/kobuki_ros.git', version: 'bugfix/pessimizing-move' }
+  cmv_vel_mux      : { type: 'git', url: 'https://github.com/kobuki-base/cmd_vel_mux.git',  version: 'devel' }

--- a/kobuki_standalone.repos
+++ b/kobuki_standalone.repos
@@ -6,7 +6,6 @@
 repositories:
   # Kobuki dependencies
   ecl_lite         : { type: 'git', url: 'https://github.com/ingotrobotics/ecl_lite.git',   version: 'bugfix/jazzy_error_overloaded-virtual' }
-  #ecl_core         : { type: 'git', url: 'https://github.com/stonier/ecl_core.git',         version: 'devel' }
   ecl_core         : { type: 'git', url: 'https://github.com/ingotrobotics/ecl_core.git',   version: 'bugfix/ecl_utilities_maybe-uninitialized' }
 
   # Kobuki

--- a/kobuki_standalone.repos
+++ b/kobuki_standalone.repos
@@ -6,7 +6,8 @@
 repositories:
   # Kobuki dependencies
   ecl_lite         : { type: 'git', url: 'https://github.com/ingotrobotics/ecl_lite.git',   version: 'bugfix/jazzy_error_overloaded-virtual' }
-  ecl_core         : { type: 'git', url: 'https://github.com/stonier/ecl_core.git',         version: 'devel' }
+  #ecl_core         : { type: 'git', url: 'https://github.com/stonier/ecl_core.git',         version: 'devel' }
+  ecl_core         : { type: 'git', url: 'https://github.com/ingotrobotics/ecl_core.git',   version: 'bugfix/ecl_utilities_maybe-uninitialized' }
 
   # Kobuki
   kobuki_core      : { type: 'git', url: 'https://github.com/kobuki-base/kobuki_core.git',  version: 'devel' }

--- a/turtlebot2_ros2.dockerfile
+++ b/turtlebot2_ros2.dockerfile
@@ -23,10 +23,8 @@ WORKDIR $KOBUKI_BUILD_SPACE
 #RUN wget -q https://raw.githubusercontent.com/kobuki-base/kobuki_documentation/release/1.0.x/resources/kobuki_standalone.repos
 COPY kobuki_standalone.repos .
 
-# Use vcs
+# Use vcs to import source repos
 RUN mkdir -p $ROBOT_WORKSPACE/src && vcs import $ROBOT_WORKSPACE/src < $KOBUKI_BUILD_SPACE/kobuki_standalone.repos
-# ecl_utilities won't compile from source (yet) but has an apt package available
-RUN rm -rf $ROBOT_WORKSPACE/src/ecl_core/ecl_utilities
 
 # Install dependencies
 WORKDIR $ROBOT_WORKSPACE
@@ -38,7 +36,6 @@ SHELL ["/bin/bash", "-c"]
 ARG parallel_jobs=8
 WORKDIR $ROBOT_WORKSPACE
 RUN source "/opt/ros/$ROS_DISTRO/setup.bash" && colcon build --parallel-workers $parallel_jobs --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo
-#    -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
 FROM $from_image AS mobile_base
 


### PR DESCRIPTION
The build options for ROS 2 Jazzy and Ubuntu Noble required some small bug fixes in ecl_lite and kobuki_ros. I have created PRs for those fixes, but in the mean time, I have created a local kobuki_standalone.repos which points to those bug fix branches.

I have built and tested this branch on Ingot Robotics' Jenkins instance and Turtlebot2 platform.