### PR TITLE
Revert to koubki_base/kobuki_ros

### DIFF
--- a/kobuki_standalone.repos
+++ b/kobuki_standalone.repos
@@ -10,5 +10,5 @@ repositories:
 
   # Kobuki
   kobuki_core      : { type: 'git', url: 'https://github.com/kobuki-base/kobuki_core.git',  version: 'devel' }
-  kobuki_ros       : { type: 'git', url: 'https://github.com/ingotrobotics/kobuki_ros.git', version: 'bugfix/pessimizing-move' }
+  kobuki_ros       : { type: 'git', url: 'https://github.com/kobuki-base/kobuki_ros.git',   version: 'devel' }
   cmv_vel_mux      : { type: 'git', url: 'https://github.com/kobuki-base/cmd_vel_mux.git',  version: 'devel' }


### PR DESCRIPTION
kobuki_base/kobuki_ros merged our bugfix PR. This PR reverts our turtlebot2 builds to use the official kobuki_ros repo again.